### PR TITLE
fix: pacman auto-track hook silently fails to track removals

### DIFF
--- a/arch/packages/aur.txt
+++ b/arch/packages/aur.txt
@@ -4,11 +4,9 @@ catppuccin-gtk-theme-mocha
 cheat
 checkstyle
 claude-desktop-appimage
-docker-desktop
 espanso-wayland-bin
 google-chrome
 hyprswitch
-intellij-idea-ultimate-edition
 jql
 neofetch-git
 ngrok

--- a/arch/packages/packages.txt
+++ b/arch/packages/packages.txt
@@ -164,6 +164,7 @@ libplasma
 libpulse
 libreoffice-fresh
 libva-intel-driver
+libxcrypt-compat
 linux
 linux-firmware
 linux-lts

--- a/arch/packages/packages.txt
+++ b/arch/packages/packages.txt
@@ -199,6 +199,7 @@ oxygen
 oxygen-sounds
 pacman-contrib
 papers
+pass
 pavucontrol
 pipewire
 pipewire-alsa

--- a/arch/scripts/pkgtrack.sh
+++ b/arch/scripts/pkgtrack.sh
@@ -48,6 +48,8 @@ echo "$AUR_PACKAGES" > "$AUR_FILE"
 
 NEW_PKGS=$(comm -13 <(sort "$OLD_PACKAGES_FILE") "$PACKAGES_FILE" | tr '\n' ' ' | sed 's/  */ /g' | sed 's/^ *//;s/ *$//')
 NEW_AUR=$(comm -13 <(sort "$OLD_AUR_FILE") "$AUR_FILE" | tr '\n' ' ' | sed 's/  */ /g' | sed 's/^ *//;s/ *$//')
+DEL_PKGS=$(comm -23 <(sort "$OLD_PACKAGES_FILE") "$PACKAGES_FILE" | tr '\n' ' ' | sed 's/  */ /g' | sed 's/^ *//;s/ *$//')
+DEL_AUR=$(comm -23 <(sort "$OLD_AUR_FILE") "$AUR_FILE" | tr '\n' ' ' | sed 's/  */ /g' | sed 's/^ *//;s/ *$//')
 
 rm -f "$OLD_PACKAGES_FILE" "$OLD_AUR_FILE"
 
@@ -56,6 +58,8 @@ AUR_COUNT=$(wc -l < "$AUR_FILE" 2>/dev/null || echo "0")
 
 [[ -n "$NEW_PKGS" ]] && echo "[+] New official packages: $NEW_PKGS" || NEW_PKGS="none"
 [[ -n "$NEW_AUR" ]] && echo "[+] New AUR packages: $NEW_AUR" || NEW_AUR="none"
+[[ -n "$DEL_PKGS" ]] && echo "[-] Removed official packages: $DEL_PKGS" || DEL_PKGS="none"
+[[ -n "$DEL_AUR" ]] && echo "[-] Removed AUR packages: $DEL_AUR" || DEL_AUR="none"
 
 cd "$DOTFILES_DIR" || exit 1
 
@@ -66,17 +70,28 @@ for bat in /sys/class/power_supply/BAT*; do
     [[ -d "$bat" ]] && { MACHINE="laptop"; break; }
 done
 
-if [[ "$NEW_AUR" != "none" && "$NEW_PKGS" != "none" ]]; then
-    COMMIT_MSG="[AUTO] [$DATE] [$HOSTNAME:$MACHINE] Packages: $NEW_PKGS | AUR: $NEW_AUR"
-elif [[ "$NEW_AUR" != "none" ]]; then
-    COMMIT_MSG="[AUTO] [$DATE] [$HOSTNAME:$MACHINE] AUR Packages: $NEW_AUR"
-else
-    COMMIT_MSG="[AUTO] [$DATE] [$HOSTNAME:$MACHINE] Packages: $NEW_PKGS"
-fi
-
-if [[ "$NEW_PKGS" == "none" && "$NEW_AUR" == "none" ]]; then
+if [[ "$NEW_PKGS" == "none" && "$NEW_AUR" == "none" && "$DEL_PKGS" == "none" && "$DEL_AUR" == "none" ]]; then
     exit 0
 fi
+
+# A single pacman -Rns can touch 100+ packages, so keep the subject readable
+summarize() {
+    local n
+    n=$(wc -w <<< "$1")
+    if (( n > 5 )); then
+        echo "$(cut -d' ' -f1-5 <<< "$1") and $((n - 5)) more"
+    else
+        echo "$1"
+    fi
+}
+
+parts=()
+[[ "$NEW_PKGS" != "none" ]] && parts+=("+$(summarize "$NEW_PKGS")")
+[[ "$NEW_AUR" != "none" ]] && parts+=("+AUR $(summarize "$NEW_AUR")")
+[[ "$DEL_PKGS" != "none" ]] && parts+=("-$(summarize "$DEL_PKGS")")
+[[ "$DEL_AUR" != "none" ]] && parts+=("-AUR $(summarize "$DEL_AUR")")
+
+COMMIT_MSG="[AUTO] [$DATE] [$HOSTNAME:$MACHINE] $(IFS='|'; echo "${parts[*]}")"
 
 echo "Committing package changes..."
 echo "Official packages: $NEW_COUNT"

--- a/shared/scripts/config.sh
+++ b/shared/scripts/config.sh
@@ -11,7 +11,7 @@
 #   1. $DOTFILES_DIR env var (if set and valid)
 #   2. Search list of common clone locations
 
-if [[ -z "$DOTFILES_DIR" || ! -d "$DOTFILES_DIR/.git" ]]; then
+if [[ -z "${DOTFILES_DIR:-}" || ! -d "${DOTFILES_DIR:-}/.git" ]]; then
     for _path in \
         "$HOME/Desktop/dotfiles" \
         "$HOME/dotfiles" \
@@ -37,7 +37,7 @@ fi
 
 # Color logger
 _dotfiles_color() {
-    if [[ -n "$NO_COLOR" || ! -t 1 ]]; then
+    if [[ -n "${NO_COLOR:-}" || ! -t 1 ]]; then
         printf "%s" "$2"
     else
         printf "\033[%sm%s\033[0m" "$1" "$2"


### PR DESCRIPTION
## Summary

Fixes two stacked bugs in the pacman auto-track hook that caused it to silently never work:

1. Unguarded variable references in config.sh under set -u
2. Package removals never being committed (comm -13 only finds additions)

## Test Plan

- Removal path tested by restoring aur.txt and re-running (correctly detected and committed docker-desktop + intellij-idea-ultimate-edition)
- List truncation tested by dropping 6 entries from packages.txt (produced "+zip zoxide zram-generator zsh zsh-autosuggestions and 1 more")
- Live test: hook ran on a real `pacman -S pass`, committed and pushed on its own

Closes #1

---

### Follow-up

The hook currently commits and pushes to whatever branch happens to be checked out, scattering [AUTO] commits onto feature branches during active development. Should pin to master in a separate change.