### PR TITLE
Keep MATLAB on hardware rendering, quiet fontconfig noise

### DIFF
--- a/shared/stow/scripts/.local/bin/matlab
+++ b/shared/stow/scripts/.local/bin/matlab
@@ -12,4 +12,23 @@ if [[ ! -x "$root/bin/matlab" ]]; then
     exit 1
 fi
 
-exec "$root/bin/matlab" "$@"
+# MATLAB bundles a gcc-12 libstdc++ and searches its own lib dir first. System
+# Mesa needs newer symbols than that copy has, so the DRI driver fails to load
+# and MATLAB silently falls back to SwiftShader on the CPU. MathWorks ships
+# these only "in the event that your distribution does not provide them"
+# (see README.libgcc_s), so move them aside. Updates put them back, hence the
+# check on every launch.
+libdir="$root/sys/os/glnxa64"
+if [[ -e "$libdir/libstdc++.so.6" ]]; then
+    for lib in "$libdir"/libstdc++.so.6*; do
+        [[ "$lib" == *.bak ]] && continue
+        mv "$lib" "$lib.bak" 2>/dev/null ||
+            echo "matlab: could not move $lib aside, expect software rendering" >&2
+    done
+fi
+
+# CEF links an older fontconfig that cannot parse fontconfig 2.18 config files,
+# so every launch prints ~90 warnings about syntax the system handles fine.
+# Drop those lines only; everything else on stderr still comes through.
+exec "$root/bin/matlab" "$@" \
+    2> >(grep --line-buffered -v '^Fontconfig warning: ' >&2)


### PR DESCRIPTION
Closes #5

Two changes to `shared/stow/scripts/.local/bin/matlab`.

**Hardware rendering.** Moves MATLAB's bundled `libstdc++.so.6*` aside when it finds it, so system Mesa can load its DRI driver. Verified: `rendererinfo` went from SwiftShader with `HardwareSupportLevel: 'None'` to `ANGLE (Intel, Mesa Intel(R) UHD Graphics (CML GT2), OpenGL 4.6)`. The check runs every launch because a MATLAB update restores the bundled copy and the only symptom is a log line.

**Startup noise.** Filters `Fontconfig warning:` lines out of stderr. Everything else passes through.

Tested against a throwaway MATLAB tree: both libraries got renamed, a fake `Fontconfig warning:` line was hidden, a fake `MESA-LOADER:` line came through, and exit codes pass through unchanged.