### PR TITLE
Readable, durable workspace labels and memory hardening

### DIFF
--- a/arch/packages/packages.txt
+++ b/arch/packages/packages.txt
@@ -25,6 +25,7 @@ breeze-gtk
 breeze-plymouth
 brightnessctl
 btop
+bullet
 cava
 chafa
 choose
@@ -71,6 +72,7 @@ git
 git-delta
 github-cli
 git-lfs
+glm
 glow
 gnome-backgrounds
 gnome-calculator
@@ -249,6 +251,7 @@ rygel
 sd
 sddm
 sddm-kcm
+sfml
 shellcheck
 showtime
 simple-scan

--- a/arch/packages/packages.txt
+++ b/arch/packages/packages.txt
@@ -273,6 +273,7 @@ television
 texlive-basic
 texlive-fontsrecommended
 texlive-latexextra
+thermald
 thunar
 thunar-volman
 tldr

--- a/arch/packages/packages.txt
+++ b/arch/packages/packages.txt
@@ -244,6 +244,7 @@ qt5-wayland
 qt6ct
 qt6-wayland
 r
+rclone
 reflector
 rsync
 rustup

--- a/arch/packages/packages.txt
+++ b/arch/packages/packages.txt
@@ -48,6 +48,7 @@ dog
 doggo
 dolphin
 dolphin-plugins
+dolt
 drkonqi
 dunst
 dust
@@ -100,6 +101,7 @@ gnome-tweaks
 gnome-user-docs
 gnome-user-share
 gnome-weather
+go
 gparted
 gping
 grilo-plugins

--- a/arch/stow/hypr-host/.config/hypr/host.conf
+++ b/arch/stow/hypr-host/.config/hypr/host.conf
@@ -15,4 +15,5 @@ device {
 }
 
 # Dock (nwg-dock works correctly on Arch, use wlr/taskbar in waybar on Ubuntu instead)
-exec-once = nwg-dock-hyprland -i 32 -nolauncher -l top -mb -49 -o eDP-1
+# Top edge, since waybar owns the bottom and the dock grows wider as windows open.
+exec-once = nwg-dock-hyprland -i 32 -nolauncher -l top -p top -o eDP-1

--- a/arch/stow/hypr-host/.config/hypr/host.lua
+++ b/arch/stow/hypr-host/.config/hypr/host.lua
@@ -21,6 +21,7 @@ hl.device({
 
 -- Dock (nwg-dock works correctly on Arch, use wlr/taskbar in waybar on Ubuntu instead)
 hl.on("hyprland.start", function()
-    hl.exec_cmd("nwg-dock-hyprland -i 32 -nolauncher -l top -mb -49 -o eDP-1")
+    -- Top edge, since waybar owns the bottom and the dock widens as windows open.
+    hl.exec_cmd("nwg-dock-hyprland -i 32 -nolauncher -l top -p top -o eDP-1")
 end)
 

--- a/arch/stow/systemd/.config/systemd/user/app.slice.d/10-oomd.conf
+++ b/arch/stow/systemd/.config/systemd/user/app.slice.d/10-oomd.conf
@@ -1,0 +1,6 @@
+# Let systemd-oomd kill the single hungriest app scope under sustained memory
+# pressure, instead of letting the kernel OOM killer pick at random. Without
+# this a browser, an editor and a shell all die in the same second.
+[Slice]
+ManagedOOMMemoryPressure=kill
+ManagedOOMMemoryPressureLimit=80%

--- a/shared/stow/hypr/.config/hypr/hyprland.lua
+++ b/shared/stow/hypr/.config/hypr/hyprland.lua
@@ -31,8 +31,16 @@ hl.on("hyprland.start", function()
     hl.exec_cmd("avizo-daemon")                      -- Volume/brightness overlay
     hl.exec_cmd("~/.config/hypr/scripts/assign_workspaces.sh")
     hl.exec_cmd("~/.config/hypr/scripts/monitor_watch.sh")
+    hl.exec_cmd("~/.config/hypr/scripts/workspace_names.sh")  -- Restore workspace labels
     -- hl.exec_cmd("hyprswitch init --daemon")       -- Mac-like Alt+Tab
 end)
+
+
+-- Workspaces 1 to 6 always exist. An emptied workspace would otherwise be
+-- destroyed and take its label with it.
+for i = 1, 6 do
+    hl.workspace_rule({ workspace = tostring(i), persistent = true })
+end
 
 
 -- Environment variables (GPU-specific env goes in per-host host.lua)

--- a/shared/stow/hypr/.config/hypr/keybindings.lua
+++ b/shared/stow/hypr/.config/hypr/keybindings.lua
@@ -101,6 +101,7 @@ hl.bind(mod .. " + CTRL + SHIFT + SPACE", hl.dsp.exec_cmd(scripts .. "/switch_la
 hl.bind(mod .. " + CTRL + SHIFT + 6", hl.dsp.exec_cmd(scripts .. "/switch_refreshrate.sh"))
 hl.bind(mod .. " + CTRL + SHIFT + 7", hl.dsp.exec_cmd(scripts .. "/speaker_toggle.sh"))
 hl.bind(mod .. " + CTRL + SHIFT + 0", hl.dsp.exec_cmd(scripts .. "/screen_manager.sh"))
+hl.bind(mod .. " + SHIFT + R", hl.dsp.exec_cmd(scripts .. "/rename_workspace.sh"))      -- Rename workspace
 
 
 -- Special character input

--- a/shared/stow/hypr/.config/hypr/scripts/kill_confirm.sh
+++ b/shared/stow/hypr/.config/hypr/scripts/kill_confirm.sh
@@ -10,12 +10,14 @@ if [ -z "$WINDOW_TITLE" ] || [ "$WINDOW_TITLE" = "null" ]; then
     WINDOW_TITLE="$WINDOW_CLASS"
 fi
 
-# Show elegant wofi dialog (kun popup, ingen varsling)
-CHOICE=$(echo -e "✓ Close window\n✗ Keep open" | wofi \
+# Red dialog. Destructive actions must not look like the launcher.
+CHOICE=$(printf '%s\n' "Close $WINDOW_TITLE" "Keep it open" | wofi \
     --dmenu \
-    --prompt "Close $WINDOW_CLASS?" \
-    --width 350 \
-    --height 150 \
+    --prompt "Close this window?" \
+    --style ~/.config/wofi/confirm.css \
+    --width 460 \
+    --height 210 \
+    --lines 2 \
     --cache-file /dev/null \
     --insensitive \
     --matching fuzzy)

--- a/shared/stow/hypr/.config/hypr/scripts/monitor_watch.sh
+++ b/shared/stow/hypr/.config/hypr/scripts/monitor_watch.sh
@@ -6,11 +6,19 @@ set -euo pipefail
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 SOCKET="$XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock"
 
-nc -U "$SOCKET" | while IFS= read -r line; do
-    case "$line" in
-        monitoradded*|monitorremoved*)
-            sleep 0.5
-            "$SCRIPT_DIR/assign_workspaces.sh"
-            ;;
-    esac
+# Reconnect forever. A dropped socket read would otherwise leave monitor
+# hotplug unhandled for the rest of the session.
+while true; do
+    if [[ -S "$SOCKET" ]]; then
+        nc -U "$SOCKET" | while IFS= read -r line; do
+            case "$line" in
+                monitoradded*|monitorremoved*)
+                    sleep 0.5
+                    "$SCRIPT_DIR/assign_workspaces.sh" || true
+                    ;;
+            esac
+        done || true
+    fi
+
+    sleep 2
 done

--- a/shared/stow/hypr/.config/hypr/scripts/rename_workspace.sh
+++ b/shared/stow/hypr/.config/hypr/scripts/rename_workspace.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Label the active workspace so waybar shows what it is instead of a bare number.
+# Empty input clears the label back to the plain workspace number.
+#
+# The label is written to disk so workspace_names.sh can restore it after the
+# workspace is destroyed or the config is reloaded.
+
+STATE="${XDG_STATE_HOME:-$HOME/.local/state}/hypr/workspace_names"
+
+ws=$(hyprctl activeworkspace -j)
+id=$(jq -r '.id' <<<"$ws")
+current=$(jq -r '.name' <<<"$ws")
+
+# Strip the "3: " prefix so the prompt prefills with just the label.
+label=${current#"$id"}
+label=${label#": "}
+[[ "$label" == "$id" ]] && label=""
+
+new=$(wofi \
+    --dmenu \
+    --prompt "Name workspace $id" \
+    --search "$label" \
+    --style ~/.config/wofi/rename.css \
+    --width 460 \
+    --height 110 \
+    --exec-search \
+    --cache-file /dev/null \
+    < /dev/null | tr -d "'\"=" | tr -d '\n' || true)
+
+mkdir -p "$(dirname "$STATE")"
+touch "$STATE"
+tmp=$(mktemp)
+grep -v "^$id=" "$STATE" > "$tmp" || true
+[[ -n "$new" ]] && printf '%s=%s\n' "$id" "$new" >> "$tmp"
+sort -n -t= -k1 "$tmp" -o "$STATE"
+rm -f "$tmp"
+
+hyprctl dispatch "hl.dsp.workspace.rename({ workspace = '$id', name = '$id${new:+: $new}' })"

--- a/shared/stow/hypr/.config/hypr/scripts/workspace_names.sh
+++ b/shared/stow/hypr/.config/hypr/scripts/workspace_names.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -euo pipefail
+# Keeps workspace labels alive.
+#
+# A rename is runtime-only state in Hyprland: it dies when the workspace is
+# destroyed (last window moved away) and when the config is reloaded. Labels are
+# therefore stored on disk and reapplied whenever a workspace comes back.
+#
+# State file format, one per line: <id>=<label>
+
+STATE="${XDG_STATE_HOME:-$HOME/.local/state}/hypr/workspace_names"
+SOCKET="$XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock"
+
+apply_one() {
+    local id=$1 label=$2
+    hyprctl dispatch \
+        "hl.dsp.workspace.rename({ workspace = '$id', name = '$id${label:+: $label}' })" \
+        >/dev/null 2>&1 || true
+}
+
+apply_all() {
+    [[ -f "$STATE" ]] || return 0
+    while IFS='=' read -r id label; do
+        [[ "$id" =~ ^[0-9]+$ ]] || continue
+        apply_one "$id" "$label"
+    done < "$STATE"
+}
+
+apply_id() {
+    local want=$1 id label
+    [[ -f "$STATE" ]] || return 0
+    while IFS='=' read -r id label; do
+        [[ "$id" == "$want" ]] || continue
+        apply_one "$id" "$label"
+        return 0
+    done < "$STATE"
+}
+
+# Reconnect forever. A dropped socket read would otherwise kill the listener
+# for the rest of the session, and labels would silently stop being restored.
+while true; do
+    apply_all
+
+    if [[ -S "$SOCKET" ]]; then
+        nc -U "$SOCKET" | while IFS= read -r line; do
+            case "$line" in
+                createworkspacev2\>\>*)
+                    id=${line#createworkspacev2>>}
+                    apply_id "${id%%,*}"
+                    ;;
+                configreloaded*)
+                    apply_all
+                    ;;
+            esac
+        done || true
+    fi
+
+    sleep 2
+done

--- a/shared/stow/nwg-dock/.config/nwg-dock-hyprland/style.css
+++ b/shared/stow/nwg-dock/.config/nwg-dock-hyprland/style.css
@@ -1,6 +1,7 @@
 window {
   background: #1e1e2e;
-  border-radius: 15px 15px 0 0;
+  /* Dock hangs from the top edge, so round the bottom corners only. */
+  border-radius: 0 0 15px 15px;
   border-style: solid;
   border-width: 1px;
   border-color: rgba(50, 50, 50, 0.9);

--- a/shared/stow/waybar/.config/waybar/config.jsonc
+++ b/shared/stow/waybar/.config/waybar/config.jsonc
@@ -21,7 +21,7 @@
         "disable-scroll": true,
         "on-scroll-up": "hyprctl dispatch workspace -1 || hyprctl dispatch 'hl.dsp.focus({ workspace = \"-1\" })'",
         "on-scroll-down": "hyprctl dispatch workspace +1 || hyprctl dispatch 'hl.dsp.focus({ workspace = \"+1\" })'",
-		"format": "{name}: {windows}",
+		"format": "{name} {windows}",
 		"on-click": "activate",
 		"format-icons": {
 			"urgent": "",
@@ -30,24 +30,53 @@
 		},
 
     	"persistent-workspaces": {
-    	         "*": 5
+    	         "*": 6
         },
 
         "window-rewrite-default": "󱓻",
 	    "window-rewrite": {
-		    "title<.*youtube.*>": "", // Windows whose titles contain "youtube"
-		    "class<firefox>": "", // Windows whose classes are "firefox"
-		    "class<none>": "r", // Windows whose classes are "firefox"
-		    "class<librewolf>": "󰈹", // Windows whose classes are "firefox"
-		    "class<librewolf> title<.*github.*>": "", // Windows whose class is "firefox" and title contains "github". Note that "class" always comes first.
-		    "alacritty": "", // Windows that contain "foot" in either class or title. For optimization reasons, it will only match against a title if at least one other window explicitly matches against a title.
-		    "ghostty": "", 
-            "thunar": "󱧶", // Windows that contain "foot" in either class or title. For optimization reasons, it will only match against a title if at least one other window explicitly matches against a title.
-		    "code": "󰨞",
-		    "slack": "",
-		    "youtube-music": "󰎆",
-            "notion": "",
-		    "title<.* - (.*) - VSCodium>": "codium $1"  // captures part of the window title and formats it into output
+		    // Title rules must come before the class rule they override.
+		    "class<com.mitchellh.ghostty> title<.*(nvim|NVIM).*>": "",
+		    "title<.*youtube.*>": "",
+
+		    // Terminals
+		    "class<com.mitchellh.ghostty>": "",
+		    "class<ghostty>": "",
+		    "class<Alacritty>": "",
+		    "class<alacritty>": "",
+
+		    // Browsers
+		    "class<firefox>": "",
+		    "class<librewolf>": "󰈹",
+		    "class<brave-browser>": "󰖟",
+		    "class<brave-beta>": "󰖟",
+		    "class<google-chrome>": "",
+
+		    // Editors and dev tools
+		    "class<Code>": "󰨞",
+		    "class<code-oss>": "󰨞",
+		    "class<md.Obsidian>": "󰠮",
+		    "class<obsidian>": "󰠮",
+		    "class<DBeaver>": "󰆼",
+		    "class<Claude>": "󰚩",
+
+		    // Everything else
+		    "class<Slack>": "",
+		    "class<spotify>": "",
+		    "class<blueman-manager>": "󰂯",
+		    "class<com.cisco.secureclient.gui>": "󰖂",
+		    "class<org.gnome.Nautilus>": "󰉋",
+		    "class<dolphin>": "󰉋",
+		    "class<thunar>": "󱧶",
+
+		    // Apps that set no WM class of their own: match class or title text.
+		    "matlab": "󰄨",
+		    "rstudio": "󰟔",
+		    "libreoffice": "󰈙",
+		    "blueman": "󰂯",
+		    "cisco": "󰖂",
+		    "nautilus": "󰉋",
+		    "nvim": ""
 	    }
     },
 

--- a/shared/stow/waybar/.config/waybar/config.jsonc
+++ b/shared/stow/waybar/.config/waybar/config.jsonc
@@ -58,6 +58,7 @@
 		    "class<md.Obsidian>": "󰠮",
 		    "class<obsidian>": "󰠮",
 		    "class<DBeaver>": "󰆼",
+		    "class<com.anthropic.Claude>": "󰚩",
 		    "class<Claude>": "󰚩",
 
 		    // Everything else

--- a/shared/stow/waybar/.config/waybar/config.jsonc
+++ b/shared/stow/waybar/.config/waybar/config.jsonc
@@ -2,7 +2,7 @@
 
 
 [{
-    "layer": "top",
+    "layer": "bottom",
     "output": "eDP-1",
     "position": "bottom",
     "mod": "dock",
@@ -402,7 +402,7 @@
 }, {
     // EXTRA MONITOR CONFIGS
 
-    "layer": "top",
+    "layer": "bottom",
     "output": ["HDMI-A-1", "DP-2", "DP-3"],
     "position": "bottom",
     "mod": "dock",

--- a/shared/stow/waybar/.config/waybar/style.css
+++ b/shared/stow/waybar/.config/waybar/style.css
@@ -57,7 +57,7 @@ tooltip {
 }
 
 #workspaces button {
-  color: #868da8;
+  color: #cdd6f4;
   /*background-color: #212124;*/
   border-radius: 8px;
   padding: 0px;
@@ -71,10 +71,18 @@ tooltip {
 }
 
 #workspaces button.active {
-  color: #cdd6f4;
+  color: #cba6f7;
+  background: #313244;
   border-radius: 10px;
-  padding-left: 3px;
-  padding-right: 3px;
+  padding-left: 6px;
+  padding-right: 6px;
+}
+/* No windows on it: dimmer than an occupied workspace, still readable. */
+#workspaces button.empty {
+  color: #9399b2;
+}
+#workspaces button.empty.active {
+  color: #cba6f7;
 }
 
 #workspaces button.urgent {

--- a/shared/stow/wofi/.config/wofi/confirm.css
+++ b/shared/stow/wofi/.config/wofi/confirm.css
@@ -1,0 +1,64 @@
+/* Destructive confirmations. Red so it never reads as the launcher or the
+   rename prompt: the dialog that can lose your work looks different. */
+
+window {
+  margin: 0px;
+  border: 3px solid;
+  border-color: #f38ba8;
+  border-radius: 18px;
+  background-color: #181825;
+}
+
+#outer-box {
+  margin: 0px;
+  border: none;
+  border-radius: 18px;
+  background-color: #181825;
+}
+
+#input {
+  margin: 14px 16px 4px 16px;
+  padding: 10px 16px;
+  border: 2px solid #45475a;
+  border-radius: 12px;
+  color: #cdd6f4;
+  background-color: #1e1e2e;
+  font-family: system-ui, sans-serif;
+  font-size: 16px;
+  outline: none;
+}
+
+#input:focus {
+  border: 2px solid #f38ba8;
+}
+
+#inner-box,
+#scroll {
+  margin: 0px 10px 10px 10px;
+  border: none;
+  background-color: transparent;
+}
+
+#entry {
+  margin: 3px 6px;
+  padding: 12px 14px;
+  border: none;
+  border-radius: 10px;
+  background-color: transparent;
+}
+
+#entry:selected {
+  background-color: #45475a;
+}
+
+#text {
+  margin: 0px;
+  color: #cdd6f4;
+  font-family: system-ui, sans-serif;
+  font-size: 16px;
+}
+
+#text:selected {
+  color: #f38ba8;
+  font-weight: bold;
+}

--- a/shared/stow/wofi/.config/wofi/rename.css
+++ b/shared/stow/wofi/.config/wofi/rename.css
@@ -1,0 +1,49 @@
+/* Rename-workspace prompt. Deliberately unlike the launcher and the kill dialog:
+   mauve accent, single wide input, no result list. */
+
+window {
+  margin: 0px;
+  border: 3px solid;
+  border-color: #cba6f7;
+  border-radius: 18px;
+  background-color: #181825;
+}
+
+#outer-box {
+  margin: 0px;
+  border: none;
+  border-radius: 18px;
+  background-color: #181825;
+}
+
+#input {
+  margin: 16px;
+  padding: 14px 18px;
+  border: 2px solid #cba6f7;
+  border-radius: 12px;
+  color: #cdd6f4;
+  background-color: #1e1e2e;
+  font-family: system-ui, sans-serif;
+  font-size: 18px;
+  font-weight: bold;
+  caret-color: #cba6f7;
+  outline: none;
+}
+
+#input:focus {
+  border: 2px solid #f5c2e7;
+}
+
+#input placeholder {
+  color: #9399b2;
+  font-weight: normal;
+}
+
+/* dmenu with no entries: keep the empty list from adding dead space */
+#inner-box,
+#scroll,
+#entry {
+  margin: 0px;
+  border: none;
+  background-color: transparent;
+}


### PR DESCRIPTION
Closes #14

## What changed

**Workspace labels** (`SUPER+SHIFT+R`). A wofi prompt names the active workspace, prefilled with the current label, empty input clears it. Labels persist to `~/.local/state/hypr/workspace_names` and are restored by a socket2 listener, because a Hyprland rename dies both when the workspace is destroyed and when the config reloads. Workspaces 1 to 6 are persistent so emptying one no longer destroys it.

**Waybar.** One icon per window, so an empty workspace is obvious. Rewrite rules use the real `StartupWMClass` from each installed `.desktop` file rather than guessed names, which is why everything previously fell through to the same default dot. Empty / occupied / active are colour-coded at WCAG AA contrast.

**Wofi.** Three visually distinct dialogs. Destructive confirmation is red and names the window it will close; rename is mauve; the launcher is unchanged.

**Robustness.** `monitor_watch.sh` reconnects instead of exiting for the session on a dropped socket read. A systemd-oomd policy on the user app slice gives userspace a chance to kill one app before the kernel takes out several.

## Notes

- The bind is in `keybindings.lua`. Hyprland loads the Lua config on this machine, so `keybindings.conf` and its siblings are inert.
- The oomd drop-in must be stowed with `--no-folding`; systemd skips a drop-in directory that is itself a symlink.
- System-level memory config (zram 8G, vm tunables, `systemd-oomd` enablement) is applied but lives outside this repo.

## Verified

- `5=probe` in the state file, `hyprctl reload`, label restored.
- Killed the `nc` readers, both listeners reconnected within 4s.
- `systemctl --user show app.slice` reports `ManagedOOMMemoryPressure=kill` at 80%, and `oomctl` lists app.slice under pressure monitoring.
- Config parses as JSONC; bar rendering checked against a screenshot.

Also closes #16: all three waybar blocks now use the bottom layer so the bar stops drawing over fullscreen windows.
