### PR TITLE
Track the /etc memory tuning and install it from the repo

### DIFF
--- a/arch/etc/systemd/oomd.conf.d/thresholds.conf
+++ b/arch/etc/systemd/oomd.conf.d/thresholds.conf
@@ -1,0 +1,4 @@
+[OOM]
+# Pressure has to stay high for this long before anything is killed, so a brief
+# compile spike does not cost you a browser.
+DefaultMemoryPressureDurationSec=20s

--- a/arch/etc/systemd/zram-generator.conf
+++ b/arch/etc/systemd/zram-generator.conf
@@ -1,0 +1,5 @@
+[zram0]
+zram-size = 8192
+compression-algorithm = zstd
+swap-priority = 100
+fs-type = swap

--- a/arch/install-arch.sh
+++ b/arch/install-arch.sh
@@ -23,4 +23,35 @@ stow -d "$DOTFILES/arch/stow" -t ~ --no-folding -R \
 link_claude_config "$DOTFILES"
 enable_user_units battery-warning.timer log-gc.timer skill-gap.timer vault-reindex.timer vault-index.path
 
+# /etc is not a stow target, so system tuning is copied in instead of linked.
+install_system_configs() {
+    sudo install -D -m 0644 -o root -g root \
+        "$DOTFILES/arch/etc/systemd/zram-generator.conf" \
+        /etc/systemd/zram-generator.conf
+    sudo install -D -m 0644 -o root -g root \
+        "$DOTFILES/arch/etc/systemd/oomd.conf.d/thresholds.conf" \
+        /etc/systemd/oomd.conf.d/thresholds.conf
+
+    # Never set ManagedOOMSwap on the root slice. With zram-only swap it trips
+    # under normal load and kills the session scope holding the compositor.
+    sudo rm -f /etc/systemd/system/-.slice.d/oomd.conf
+    sudo rmdir /etc/systemd/system/-.slice.d 2>/dev/null || true
+
+    # Disk tier below zram (pri 100) so cold pages spill instead of hitting OOM.
+    if [ ! -f /home/swapfile ]; then
+        sudo fallocate -l 16G /home/swapfile
+        sudo chmod 600 /home/swapfile
+        sudo mkswap /home/swapfile >/dev/null
+    fi
+    if ! grep -q '^/home/swapfile' /etc/fstab; then
+        echo '/home/swapfile none swap defaults,pri=10 0 0' | sudo tee -a /etc/fstab >/dev/null
+    fi
+    sudo swapon /home/swapfile 2>/dev/null || true
+
+    sudo systemctl daemon-reload
+    sudo systemctl enable --now thermald
+}
+
+install_system_configs
+
 echo "Arch setup complete."


### PR DESCRIPTION
The session kills on 2026-08-23 came from an untracked file, /etc/systemd/system/-.slice.d/oomd.conf, which set ManagedOOMSwap=kill on the root slice. With zram-only swap that signal is wrong, since zram hitting 90 percent is normal rather than an emergency, and when it tripped oomd killed the session scope holding the compositor.

Deleting that file fixed the crashes. The reason it could happen at all is that nothing in the repo knew about the machine memory tuning, so it drifted silently.

This adds the zram generator config and the oomd pressure threshold under arch/etc, copied from the live files, and an install_system_configs() in the installer that puts them in place. It follows the pattern already in server/scripts/bootstrap.sh, using install -D rather than stow, because /etc is not a stow target. It also adds the disk swapfile below zram in priority so cold pages spill instead of going straight to an OOM kill, and enables thermald.

Zero oomd kills since the change.

Part of #14.