### PR TITLE
Make the nvim check pass on master

### DIFF
--- a/.github/workflows/nvim-check.yml
+++ b/.github/workflows/nvim-check.yml
@@ -46,12 +46,13 @@ jobs:
       - name: Install plugins
         run: nvim --headless "+Lazy! sync" +qa
 
-      # Lazy sync starts parser downloads it never finishes, and the leftover
-      # half-written checkout makes the next install fail on a non-empty rename.
-      - name: Clear partial parser downloads
-        run: rm -rf "$HOME/.cache/nvim"/tree-sitter-*
-
+      # Lazy sync starts parser downloads it never finishes. Reusing its cache
+      # makes the real install fail on a rename into a non-empty directory, and
+      # deleting the cache races the downloads that are still writing to it, so
+      # the smoke test gets a cache of its own.
       - name: Smoke test
+        env:
+          XDG_CACHE_HOME: ${{ runner.temp }}/nvim-smoke-cache
         run: nvim --headless -c "luafile $GITHUB_WORKSPACE/$NVIM_CONFIG/scripts/ci-check.lua"
 
       - name: stylua

--- a/shared/stow/nvim/.config/nvim/scripts/ci-check.lua
+++ b/shared/stow/nvim/.config/nvim/scripts/ci-check.lua
@@ -30,7 +30,6 @@ local ERROR_SIGNATURES = {
   "attempt to index",
   "attempt to perform",
   "nil value",
-  "stack traceback",
   "query error",
   "error executing",
   "e5108",
@@ -47,6 +46,9 @@ local function is_noise(line)
   return false
 end
 
+-- Matched per line, so a signature has to be meaningful on its own. A bare
+-- "stack traceback:" is not: it belongs to the error above it, which is either
+-- already noise or already matched.
 local function is_error(line)
   if is_noise(line) then
     return false


### PR DESCRIPTION
The check went green on the feature branch and red on master, for two reasons that only showed up once the earlier races were gone.

Lazy sync starts treesitter downloads and exits without finishing them. Reusing that cache made the real install fail on a rename into a non-empty directory, and deleting the cache raced the downloads still writing to it, so rm failed before the test even ran. The smoke test now gets a cache directory of its own, which sidesteps both.

The second one was mine: the message log is scanned line by line, and a bare "stack traceback:" matched on its own even when the error above it was environment noise the check already ignores.