### PR TITLE
Move the dock to the bottom and hide it behind windows

### DIFF
--- a/arch/stow/hypr-host/.config/hypr/host.conf
+++ b/arch/stow/hypr-host/.config/hypr/host.conf
@@ -15,5 +15,6 @@ device {
 }
 
 # Dock (nwg-dock works correctly on Arch, use wlr/taskbar in waybar on Ubuntu instead)
-# Top edge, since waybar owns the bottom and the dock grows wider as windows open.
-exec-once = nwg-dock-hyprland -i 32 -nolauncher -l top -p top -o eDP-1
+# Bottom edge, resting on waybar. The empty-workspace toggle lives in host.lua,
+# which is the config Hyprland actually loads here.
+exec-once = nwg-dock-hyprland -i 32 -nolauncher -l top -p bottom -o eDP-1

--- a/arch/stow/hypr-host/.config/hypr/host.lua
+++ b/arch/stow/hypr-host/.config/hypr/host.lua
@@ -20,8 +20,19 @@ hl.device({
 })
 
 -- Dock (nwg-dock works correctly on Arch, use wlr/taskbar in waybar on Ubuntu instead)
-hl.on("hyprland.start", function()
-    -- Top edge, since waybar owns the bottom and the dock widens as windows open.
-    hl.exec_cmd("nwg-dock-hyprland -i 32 -nolauncher -l top -p top -o eDP-1")
-end)
+--
+-- It rests on waybar at the bottom, so any window on the workspace sits under
+-- it. Run it only while the workspace is empty: start it when the last window
+-- goes, kill it when the first one arrives.
+local dock = "nwg-dock-hyprland -i 32 -nolauncher -l top -p bottom -o eDP-1"
+local sync_dock = 'if [ "$(hyprctl activeworkspace -j | jq .windows)" -eq 0 ]; then '
+    .. "pgrep -x nwg-dock-hyprla >/dev/null || setsid "
+    .. dock
+    .. " >/dev/null 2>&1 & else pkill -x nwg-dock-hyprla; fi"
+
+for _, event in ipairs({ "hyprland.start", "window.open", "window.close", "workspace.active" }) do
+    hl.on(event, function()
+        hl.exec_cmd(sync_dock)
+    end)
+end
 

--- a/shared/stow/hypr/.config/hypr/scripts/theme_apply.sh
+++ b/shared/stow/hypr/.config/hypr/scripts/theme_apply.sh
@@ -297,7 +297,7 @@ done
 if pgrep -x nwg-dock-hyprla >/dev/null 2>&1; then
     pkill -x nwg-dock-hyprla || true
     sleep 0.3
-    setsid nwg-dock-hyprland -i 32 -nolauncher -l top -p top -o eDP-1 \
+    setsid nwg-dock-hyprland -i 32 -nolauncher -l top -p bottom -o eDP-1 \
         </dev/null >/dev/null 2>&1 &
 fi
 

--- a/shared/stow/nwg-dock/.config/nwg-dock-hyprland/style.css
+++ b/shared/stow/nwg-dock/.config/nwg-dock-hyprland/style.css
@@ -2,8 +2,8 @@
 
 window {
   background: @bg_base;
-  /* Dock hangs from the top edge, so round the bottom corners only. */
-  border-radius: 0 0 15px 15px;
+  /* waybar is transparent behind the dock, so all four corners show. */
+  border-radius: 15px;
   border-style: solid;
   border-width: 1px;
   border-color: @border_subtle;


### PR DESCRIPTION
The dock sat at the top edge and covered the top of whatever was on screen. It now runs with -p bottom, where nwg-dock honours waybar's exclusive zone and lands above the bar instead of under it.

That still leaves it over the bottom of any window on the workspace, so host.lua starts and kills the process on hyprland.start, window.open, window.close and workspace.active: dock up when the active workspace is empty, gone as soon as a window appears. nwg-dock has no toggle command, so start and kill is the only mechanism available.

Verified live: empty workspace puts it at 885,980 150x50 with waybar at 0,1030 1920x50, opening a window kills it, closing the last one brings it back, and two runs never leave a duplicate process. Corner rounding goes back to all four, since waybar is transparent behind the dock.

Closes #21