### PR TITLE
feat(server): sync Claude setup to prod

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -18,6 +18,7 @@ bash server/install-server.sh           # packages, stow, xdg
 ## Scripts
 
 - `scripts/bootstrap.sh` - one-shot, idempotent. sshd hardening, lid policy, `/srv`, UFW (ssh + tailnet), strips Hyprland/GUI/audio if present.
+- `scripts/sync-prod.sh` - run from the laptop: pulls dotfiles and claude-config master on the server, mirrors `~/vault`, lessons and project memory, installs the claude CLI and its plugins.
 - `scripts/svc-new.sh` - `sudo bash svc-new.sh <name>` creates `/srv/<name>/` with its own `svc_<name>` system user. A container escape gets `svc_<name>`, not `tri`, not root.
 
 ## Networking

--- a/server/scripts/sync-prod.sh
+++ b/server/scripts/sync-prod.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Bring the server's Claude setup in line with this laptop.
+# Dotfiles and claude-config come from GitHub master, the vault and Claude
+# state are mirrored from here. Run from the laptop: bash server/scripts/sync-prod.sh [host]
+set -euo pipefail
+
+HOST="${1:-prod}"
+VAULT="${VAULT:-$HOME/vault}"
+DOTFILES="$(cd "$(dirname "$0")/../.." && pwd)"
+
+if [ -n "$(git -C "$DOTFILES" status --porcelain --untracked-files=no)" ]; then
+    echo "note: local dotfiles has uncommitted changes, server gets origin/master" >&2
+fi
+
+remote() {
+    set -euo pipefail
+    if [ ! -d ~/dotfiles ]; then
+        git clone --recurse-submodules git@github.com:TriTacLe/dotfiles.git ~/dotfiles
+    fi
+    git -C ~/dotfiles checkout -q master
+    git -C ~/dotfiles pull -q --ff-only
+    git -C ~/dotfiles submodule update --init --recursive
+    # Track claude-config master, not the pin, so the server never lags the laptop.
+    git -C ~/dotfiles/claude-config checkout -q master
+    git -C ~/dotfiles/claude-config pull -q --ff-only
+
+    echo server > ~/.dotfiles-role
+    bash ~/dotfiles/install.sh
+
+    if ! command -v claude >/dev/null 2>&1 && [ ! -x ~/.local/bin/claude ]; then
+        curl -fsSL https://claude.ai/install.sh | bash
+    fi
+    export PATH="$HOME/.local/bin:$PATH"
+
+    if [ ! -f ~/.claude/settings.local.json ]; then
+        cat > ~/.claude/settings.local.json <<'JSON'
+{
+  "additionalDirectories": [
+    "~/dotfiles",
+    "~/vault",
+    "~/srv"
+  ]
+}
+JSON
+    fi
+}
+
+# -A forwards the laptop's ssh agent so the clones and pulls use its GitHub key.
+ssh -A -t "$HOST" "$(declare -f remote); remote"
+
+RSYNC=(rsync -a --info=stats1)
+"${RSYNC[@]}" --delete \
+    --exclude '.obsidian/workspace*' --exclude '.obsidian/cache/' \
+    --exclude '.trash/' --exclude '.obsidian/.trash/' \
+    "$VAULT/" "$HOST:vault/"
+
+"${RSYNC[@]}" --delete "$HOME/.claude/lessons/" "$HOST:.claude/lessons/"
+(cd "$HOME/.claude" && "${RSYNC[@]}" -R projects/*/memory/ "$HOST:.claude/")
+
+if [ -f "$DOTFILES/claude-config/scripts/.env" ]; then
+    "${RSYNC[@]}" "$DOTFILES/claude-config/scripts/.env" "$HOST:dotfiles/claude-config/scripts/.env"
+fi
+
+ssh -t "$HOST" 'PATH="$HOME/.local/bin:$PATH" bash ~/dotfiles/claude-config/scripts/bootstrap.sh'
+echo "synced $HOST"


### PR DESCRIPTION
Adds server/scripts/sync-prod.sh, run from the laptop. The server pulls dotfiles and claude-config master, the laptop mirrors ~/vault, ~/.claude/lessons and projects/*/memory over rsync, then the claude CLI and its plugins and MCPs get installed. Vault sync is one way (laptop canonical) because the local vault has hundreds of uncommitted changes, so git pull there would be wrong. Prod was offline while writing this, so the first real run is still pending.

Closes #27