### PR TITLE
Fix the pre-push hook hanging on a new ref

### DIFF
--- a/shared/stow/git/.git-hooks/pre-push
+++ b/shared/stow/git/.git-hooks/pre-push
@@ -65,12 +65,14 @@ while read local_ref local_sha remote_ref remote_sha; do
     fi
 
     if [[ "$remote_sha" == "0000000000000000000000000000000000000000" ]]; then
-        range="$local_sha"
+        # New ref on the remote, so there is no range to diff against. Scan the
+        # commits that are not on any remote yet. Passing a single sha to git diff
+        # compares the working tree against that commit rather than the commit
+        # against its parent, which on a large repo walks everything and hangs.
+        diff=$(git log -p --no-color "$local_sha" --not --remotes 2>/dev/null)
     else
-        range="$remote_sha..$local_sha"
+        diff=$(git diff --no-color "$remote_sha..$local_sha" 2>/dev/null)
     fi
-
-    diff=$(git diff --no-color "$range" 2>/dev/null)
     [[ -z "$diff" ]] && diff=$(git show "$local_sha" 2>/dev/null)
 
     found=()


### PR DESCRIPTION
Closes #29

When the remote side has no ref yet, remote_sha comes through as all zeros and the hook was handing a single sha to git diff. That form of git diff compares the working tree against the commit, not the commit against its parent, so the scan covered every uncommitted change in the repo rather than the commits actually being pushed.

That caused a false positive and a hang. An uncommitted secret in the working tree would block a push that did not contain it. And pushing a subtree split of one directory into an empty repo made git diff report every other file in the repo as removed, which the per-line loop, running three grep subprocesses a line, never worked through. It had to be killed.

Replaced with git log -p over the commits not already on a remote. Verified four cases by hand: a clean new ref exits 0, a secret on a new ref is still caught and exits 1, a dirty working tree is correctly ignored where it used to trip the scanner, and a normal push with a real range is unchanged and instant. The subtree push that previously hung now finishes in 21 seconds.

That 21 seconds is all in the per-line loop, which shells out three times per added line. Worth replacing with bash native matching later, but that changes a security check so it is not folded in here.